### PR TITLE
Better spacing for fit curves

### DIFF
--- a/pyEvalData/evalData.py
+++ b/pyEvalData/evalData.py
@@ -1019,7 +1019,7 @@ class spec(object):
                  sequenceType='text', labelText='', titleText='', yText='', 
                  xText='', select='', fitReport=0, showSingle=False, 
                  weights=False, fitMethod='leastsq', offsetT0 = False, 
-                 plotSeparate = False, gridOn = True, fmt='o'):
+                 plotSeparate = False, gridOn = True, fmt='-o'):
         """Fit, plot, and return the data of scans.
             
             This is just a wrapper for the fitScanSequence method
@@ -1040,7 +1040,7 @@ class spec(object):
                         fitReport=0, showSingle=False, weights=False, 
                         fitMethod='leastsq', offsetT0 = False, 
                         plotSeparate = False, gridOn = True, 
-                        lastResAsPar=False, sequenceData=[], fmt='o'):
+                        lastResAsPar=False, sequenceData=[], fmt='-o'):
         """Fit, plot, and return the data of a scan sequence.
         
         Args:

--- a/pyEvalData/evalData.py
+++ b/pyEvalData/evalData.py
@@ -1267,7 +1267,7 @@ class spec(object):
                         subplot( (numSubplots+numSubplots%2)/2,2,k)
                     
                     # plot the fit and the data as errorbars
-                    x2plotFit = arange(min(x2plot), max(x2plot), 0.010)
+                    x2plotFit = linspace(min(x2plot), max(x2plot), 1000)
                     plt = plot(x2plotFit-offsetX, out.eval(x=x2plotFit), '-', lw=2, alpha=1)
                     errorbar(x2plot-offsetX,y2plot,fmt=fmt, xerr=xerr2plot, yerr=yerr2plot, label=_lt, alpha=0.25, color=plt[0].get_color())
                     
@@ -1339,7 +1339,7 @@ class spec(object):
                         #print(i*k+k+numSubplots*len(parameters))
                         #ax2 = subplot(gs[i*numSubplots+k-1+numSubplots*len(parameters)])
                         ax2 = subplot(gs[1])
-                        x2plotFit = arange(min(x2plot), max(x2plot), 0.010)
+                        x2plotFit = linspace(min(x2plot), max(x2plot), 1000)
                         ax2.plot(x2plotFit-offsetX, out.eval(x=x2plotFit), '-', lw=2, alpha=1, color=plt[0].get_color())
                         ax2.errorbar(x2plot-offsetX,y2plot,fmt=fmt, xerr=xerr2plot, yerr=yerr2plot, label=_lt, alpha=0.25, color=plt[0].get_color())
                         legend(frameon=True,loc=0,numpoints=1)
@@ -1489,6 +1489,7 @@ class Pilatus100k(ImageReader):
                              byte_swap=False, **keyargs)
         
         
+
 ###########################
 
 class areaDetector(spec):
@@ -1986,6 +1987,8 @@ class princtonPM3(areaDetector):
         return frames
         
     
+        
+        
 ########################################
         
 class pilatusXPP(areaDetector):

--- a/pyEvalData/evalData.py
+++ b/pyEvalData/evalData.py
@@ -1267,7 +1267,7 @@ class spec(object):
                         subplot( (numSubplots+numSubplots%2)/2,2,k)
                     
                     # plot the fit and the data as errorbars
-                    x2plotFit = linspace(min(x2plot), max(x2plot), 1000)
+                    x2plotFit = arange(min(x2plot), max(x2plot), 0.010)
                     plt = plot(x2plotFit-offsetX, out.eval(x=x2plotFit), '-', lw=2, alpha=1)
                     errorbar(x2plot-offsetX,y2plot,fmt=fmt, xerr=xerr2plot, yerr=yerr2plot, label=_lt, alpha=0.25, color=plt[0].get_color())
                     
@@ -1339,7 +1339,7 @@ class spec(object):
                         #print(i*k+k+numSubplots*len(parameters))
                         #ax2 = subplot(gs[i*numSubplots+k-1+numSubplots*len(parameters)])
                         ax2 = subplot(gs[1])
-                        x2plotFit = linspace(min(x2plot), max(x2plot), 1000)
+                        x2plotFit = arange(min(x2plot), max(x2plot), 0.010)
                         ax2.plot(x2plotFit-offsetX, out.eval(x=x2plotFit), '-', lw=2, alpha=1, color=plt[0].get_color())
                         ax2.errorbar(x2plot-offsetX,y2plot,fmt=fmt, xerr=xerr2plot, yerr=yerr2plot, label=_lt, alpha=0.25, color=plt[0].get_color())
                         legend(frameon=True,loc=0,numpoints=1)
@@ -1489,7 +1489,6 @@ class Pilatus100k(ImageReader):
                              byte_swap=False, **keyargs)
         
         
-
 ###########################
 
 class areaDetector(spec):
@@ -1987,8 +1986,6 @@ class princtonPM3(areaDetector):
         return frames
         
     
-        
-        
 ########################################
         
 class pilatusXPP(areaDetector):


### PR DESCRIPTION
In `fitScanSequence` the plotting steps for the fit curve were changes from` linspace` with 1000 points to `arange` with 0.010 ps steps as this is about the current minimum delay step used. This is only aparent for plotting ranges over 1000*10fs = 10ps, and below it results in less points to be plotted.


