### PR TITLE
Replace depreceated mlab's gridddata with scipy's

### DIFF
--- a/pyEvalData/evalData.py
+++ b/pyEvalData/evalData.py
@@ -763,8 +763,9 @@ class spec(object):
 
         """
 
-        from matplotlib.mlab import griddata
+        from scipy.interpolate import griddata
         from matplotlib import gridspec
+        from numpy import vstack, meshgrid
 
         # read data from spec file
         try:
@@ -792,7 +793,7 @@ class spec(object):
 
         Z = specData[cList[0]]
 
-        zz = griddata(X, Y, Z, xx, yy, interp='linear')
+        zz = griddata(vstack((X,Y)).T, Z, tuple(meshgrid(xx, yy)), method='linear')
 
         if not skipPlot:
 


### PR DESCRIPTION
mlab's griddata seems to be deprecated. I suggest we replace it. Here is my suggestion using scipy. With this the contourf works again. For my quick tests the two plots before contourf show nothing, however (?).