### PR TITLE
Add 'sign' function to the math_keys list

### DIFF
--- a/pyEvalData/evaluation.py
+++ b/pyEvalData/evaluation.py
@@ -75,7 +75,7 @@ class Evaluation(object):
         self.custom_counters = []
         self.math_keys = ['mean', 'sum', 'diff', 'max', 'min', 'round', 'abs',
                           'sin', 'cos', 'tan', 'arcsin', 'arccos', 'arctan',
-                          'pi', 'exp', 'log', 'log10', 'sqrt']
+                          'pi', 'exp', 'log', 'log10', 'sqrt', 'sign']
         self.statistic_type = 'gauss'
         self.propagate_errors = True
         self.apply_data_filter = False


### PR DESCRIPTION
Use case:
Before averaging a sequence of delay scans, flip the sign of a difference counter for each scan so that they always start with positive values before time-zero. This is for example useful when the synchronization between two counters varies randomly from scan to scan.

The following example normalizes each scan to the sign of the first value:
`ev.cdef['DiffStartsPositive'] = '(Unpumped-Pumped)/sign(Unpumped-Pumped)[0]'`