### PR TITLE
Simultaneous write/read access to h5 files

### DIFF
--- a/pyEvalData/io/palxfel.py
+++ b/pyEvalData/io/palxfel.py
@@ -127,6 +127,7 @@ class PalH5(Source):
                                                self.file_name.format(scan_number) + '.h5')
 
                         try:
+                            os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
                             with h5py.File(h5_file, 'r') as h5:
                                 header = h5['R{0:04d}/header'.format(scan_number)]
 
@@ -171,6 +172,7 @@ class PalH5(Source):
                                self.file_name.format(scan.number),
                                self.file_name.format(scan.number) + '.h5')
 
+        os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
         with h5py.File(h5_file, 'r') as h5:
             entry = h5['R{0:04d}'.format(scan.number)]
             # iterate through data fields

--- a/pyEvalData/io/sardana_nexus.py
+++ b/pyEvalData/io/sardana_nexus.py
@@ -98,38 +98,43 @@ class SardanaNeXus(Source):
         nxs_file_path = os.path.join(self.file_path, self.file_name)
         try:
             os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
-            with nxs.nxload(nxs_file_path, mode='r') as nxs_file:
-                for entry in nxs_file:
-                    # check for scan number in given range
-                    entry_number = int(nxs_file[entry].entry_identifier)
-                    if (entry_number >= self.start_scan_number) and \
-                            ((entry_number <= self.stop_scan_number) or
-                                (self.stop_scan_number == -1)):
-                        last_scan_number = self.get_last_scan_number()
-                        # check if Scan needs to be re-created
-                        # if scan is not present, its the last one, or force overwrite
-                        if (entry_number not in self.scan_dict.keys()) or \
-                                (entry_number >= last_scan_number) or \
-                                self.force_overwrite:
-                            # create scan object
-                            init_mopo = {}
-                            for field in nxs_file[entry].measurement.pre_scan_snapshot:
-                                init_mopo[field] = \
-                                    nxs_file[entry]['measurement/pre_scan_snapshot'][field]
+            nxs_file = nxs.nxload(nxs_file_path, mode='r')
+        except nxs.NeXusError:
+            raise nxs.NeXusError('Sardana NeXus file \'{:s}\' does not exist!'.format(
+                nxs_file_path))
 
-                            scan = Scan(int(entry_number),
-                                        cmd=nxs_file[entry].title,
-                                        date=nxs_file[entry].start_time,
-                                        time=nxs_file[entry].start_time,
-                                        int_time=float(0),
-                                        header='',
-                                        init_mopo=init_mopo)
-                            self.scan_dict[entry_number] = scan
-                            # check if the data needs to be read as well
-                            if self.read_all_data:
-                                self.read_scan_data(self.scan_dict[entry_number])
-        except nxs.NeXusError as e:
-            raise nxs.NeXusError(e)
+        with nxs_file.nxfile:
+            for entry in nxs_file:
+                # check for scan number in given range
+                entry_number = int(nxs_file[entry].entry_identifier)
+                if (entry_number >= self.start_scan_number) and \
+                        ((entry_number <= self.stop_scan_number) or
+                            (self.stop_scan_number == -1)):
+                    last_scan_number = self.get_last_scan_number()
+                    # check if Scan needs to be re-created
+                    # if scan is not present, its the last one, or force overwrite
+                    if (entry_number not in self.scan_dict.keys()) or \
+                            (entry_number >= last_scan_number) or \
+                            self.force_overwrite:
+                        # create scan object
+                        init_mopo = {}
+                        for field in nxs_file[entry].measurement.pre_scan_snapshot:
+                            init_mopo[field] = \
+                                nxs_file[entry]['measurement/pre_scan_snapshot'][field]
+
+                        scan = Scan(int(entry_number),
+                                    cmd=nxs_file[entry].title,
+                                    date=nxs_file[entry].start_time,
+                                    time=nxs_file[entry].start_time,
+                                    int_time=float(0),
+                                    header='',
+                                    init_mopo=init_mopo)
+                        self.scan_dict[entry_number] = scan
+                        # check if the data needs to be read as well
+                        if self.read_all_data:
+                            self.read_scan_data(self.scan_dict[entry_number])
+
+        nxs_file.close()
 
     def read_raw_scan_data(self, scan):
         """read_raw_scan_data
@@ -141,34 +146,35 @@ class SardanaNeXus(Source):
 
         """
         self.log.info('read_raw_scan_data for scan #{:d}'.format(scan.number))
-        entry_name = 'entry{:d}'.format(scan.number)
         # try to open the file
         nxs_file_path = os.path.join(self.file_path, self.file_name)
         try:
             os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
-            with nxs.nxload(nxs_file_path, mode='r') as nxs_file:
-                # try to enter entry
-                try:
-                    entry = nxs_file[entry_name]
-                except nxs.NeXusError:
-                    self.log.exception('Entry #{:d} not present in NeXus file!'.format(
-                        scan.number))
-                    return
-                # iterate through data fields
-                data_list = []
-                dtype_list = []
-                for field in entry.measurement:
-                    # do not add data which is already in the pre-scan snapshot
-                    # that is tricky if it is in the snapshot and scanned ...
-                    if field != 'pre_scan_snapshot':
-                        data_list.append(entry.measurement[field])
-                        dtype_list.append((field,
-                                          entry.measurement[field].dtype,
-                                          entry.measurement[field].shape))
-                if len(data_list) > 0:
-                    scan.data = fromarrays(data_list, dtype=dtype_list)
-                else:
-                    scan.date = None
+            nxs_file = nxs.nxload(nxs_file_path, mode='r')
         except nxs.NeXusError:
             raise nxs.NeXusError('Sardana NeXus file \'{:s}\' does not exist!'.format(
                 nxs_file_path))
+        entry_name = 'entry{:d}'.format(scan.number)
+        # try to enter entry
+        try:
+            entry = nxs_file[entry_name]
+        except nxs.NeXusError:
+            self.log.exception('Entry #{:d} not present in NeXus file!'.format(scan.number))
+            return
+        # iterate through data fields
+        data_list = []
+        dtype_list = []
+        for field in entry.measurement:
+            # do not add data which is already in the pre-scan snapshot
+            # that is tricky if it is in the snapshot and scanned ...
+            if field != 'pre_scan_snapshot':
+                data_list.append(entry.measurement[field])
+                dtype_list.append((field,
+                                   entry.measurement[field].dtype,
+                                   entry.measurement[field].shape))
+        if len(data_list) > 0:
+            scan.data = fromarrays(data_list, dtype=dtype_list)
+        else:
+            scan.date = None
+
+        nxs_file.close()

--- a/pyEvalData/io/sardana_nexus.py
+++ b/pyEvalData/io/sardana_nexus.py
@@ -25,7 +25,7 @@
 
 from numpy.core.records import fromarrays
 import nexusformat.nexus as nxs
-import os.path as path
+import os
 
 from .source import Source
 from .scan import Scan
@@ -95,8 +95,9 @@ class SardanaNeXus(Source):
 
         """
         self.log.info('parse_raw')
-        nxs_file_path = path.join(self.file_path, self.file_name)
+        nxs_file_path = os.path.join(self.file_path, self.file_name)
         try:
+            os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
             nxs_file = nxs.nxload(nxs_file_path, mode='r')
         except nxs.NeXusError:
             raise nxs.NeXusError('Sardana NeXus file \'{:s}\' does not exist!'.format(
@@ -133,6 +134,8 @@ class SardanaNeXus(Source):
                         if self.read_all_data:
                             self.read_scan_data(self.scan_dict[entry_number])
 
+        nxs_file.close()
+
     def read_raw_scan_data(self, scan):
         """read_raw_scan_data
 
@@ -144,8 +147,9 @@ class SardanaNeXus(Source):
         """
         self.log.info('read_raw_scan_data for scan #{:d}'.format(scan.number))
         # try to open the file
-        nxs_file_path = path.join(self.file_path, self.file_name)
+        nxs_file_path = os.path.join(self.file_path, self.file_name)
         try:
+            os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
             nxs_file = nxs.nxload(nxs_file_path, mode='r')
         except nxs.NeXusError:
             raise nxs.NeXusError('Sardana NeXus file \'{:s}\' does not exist!'.format(
@@ -172,3 +176,5 @@ class SardanaNeXus(Source):
             scan.data = fromarrays(data_list, dtype=dtype_list)
         else:
             scan.date = None
+
+        nxs_file.close()

--- a/pyEvalData/io/sardana_nexus.py
+++ b/pyEvalData/io/sardana_nexus.py
@@ -134,8 +134,6 @@ class SardanaNeXus(Source):
                         if self.read_all_data:
                             self.read_scan_data(self.scan_dict[entry_number])
 
-        nxs_file.close()
-
     def read_raw_scan_data(self, scan):
         """read_raw_scan_data
 
@@ -176,5 +174,3 @@ class SardanaNeXus(Source):
             scan.data = fromarrays(data_list, dtype=dtype_list)
         else:
             scan.date = None
-
-        nxs_file.close()


### PR DESCRIPTION
When using h5 files in data acq, it is desired to read the scan file during the scan simultaneously.
For h5 files this feature is introduced by the `swmr` mode. However, this does not seem to be easy, following this Sardana issue: https://gitlab.com/sardana-org/sardana/-/issues/1124

A very simple solution also done by PyMCA is to disable file `locking` at all using an environmental variable:
https://github.com/h5py/h5py/issues/712#issuecomment-562980532

This PR introduces this feature when reading Sardana NeXus and PAL FEL h5 files